### PR TITLE
Adds vector that maps edge_id_t to LaneMapNum thus reducing the convertVector function duration

### DIFF
--- a/LivingCity/traffic/b18CommandLineVersion.cpp
+++ b/LivingCity/traffic/b18CommandLineVersion.cpp
@@ -54,8 +54,8 @@ void B18CommandLineVersion::runB18Simulation() {
 
   ClientGeometry cg;
   B18TrafficSimulator b18TrafficSimulator(deltaTime, &cg.roadGraph);
-  //auto all_paths = std::vector<abm::graph::vertex_t>;
-  std::vector<abm::graph::vertex_t> all_paths;
+  
+  std::vector<abm::graph::edge_id_t> all_paths;
   vector<vector<int>> all_paths_ch;
   const bool directed = true;
   auto street_graph = std::make_shared<abm::Graph>(directed);

--- a/LivingCity/traffic/b18TrafficLaneMap.cpp
+++ b/LivingCity/traffic/b18TrafficLaneMap.cpp
@@ -70,10 +70,10 @@ void B18TrafficLaneMap::createLaneMapSP(const std::shared_ptr<abm::Graph>& graph
   
 
   abm::graph::edge_id_t max_edge_id = 0;
-  for(auto it = graph_->edge_ids_.begin(); it != graph_->edge_ids_.end(); ++it){
-    max_edge_id = std::max(max_edge_id, it->second);
+  for (const std::pair<std::tuple<abm::graph::vertex_t, abm::graph::vertex_t>, abm::graph::edge_id_t > it: graph_->edge_ids_) {
+    max_edge_id = std::max(max_edge_id, it.second);
   }
-  printf("max_edge_id: %i", max_edge_id);
+  std::cout << "max_edge_id " << max_edge_id << "\n";
   edgeIdToLaneMapNum = std::vector<uint>(max_edge_id+1);
   
   // Check distribution of street length

--- a/LivingCity/traffic/b18TrafficLaneMap.h
+++ b/LivingCity/traffic/b18TrafficLaneMap.h
@@ -16,6 +16,7 @@
 #include "RoadGraph/roadGraph.h"
 #include "b18EdgeData.h"
 #include "traffic/sp/graph.h"
+#include "traffic/sp/config.h"
 
 namespace LC {
 
@@ -30,18 +31,13 @@ class B18TrafficLaneMap {
       std::vector<uchar> &trafficLights, std::map<uint,
       RoadGraph::roadGraphEdgeDesc_BI> &laneMapNumToEdgeDesc,
       std::map<RoadGraph::roadGraphEdgeDesc_BI, uint> &edgeDescToLaneMapNum);
-    /*
-  void createLaneMapSP(const std::shared_ptr<abm::Graph>& graph_, std::vector<uchar> &laneMap,
-      std::vector<B18EdgeData> &edgesData, std::vector<B18IntersectionData> &intersections,
-      std::vector<uchar> &trafficLights, std::map<uint,
-      RoadGraph::roadGraphEdgeDesc_BI> &laneMapNumToEdgeDesc,
-      std::map<RoadGraph::roadGraphEdgeDesc_BI, uint> &edgeDescToLaneMapNum);
-    */
+
   void createLaneMapSP(const std::shared_ptr<abm::Graph>& graph_, std::vector<uchar> &laneMap,
       std::vector<B18EdgeData> &edgesData, std::vector<B18IntersectionData> &intersections,
       std::vector<uchar> &trafficLights, 
-      std::map<uint, std::shared_ptr<abm::Graph::Edge>> &laneMapNumToEdgeDesc,
-      std::map<std::shared_ptr<abm::Graph::Edge>, uint> &edgeDescToLaneMapNum);
+      std::map<uint, std::shared_ptr<abm::Graph::Edge>> &laneMapNumToEdgeDescSP,
+      std::map<std::shared_ptr<abm::Graph::Edge>, uint> &edgeDescToLaneMapNumSP,
+      std::vector<uint> &edgeIdToLaneMapNum);
 
   void resetIntersections(std::vector<B18IntersectionData> &intersections,
                           std::vector<uchar> &trafficLights);

--- a/LivingCity/traffic/b18TrafficSP.cpp
+++ b/LivingCity/traffic/b18TrafficSP.cpp
@@ -127,10 +127,10 @@ std::vector<float> B18TrafficSP::read_dep_times(const std::string& filename) {
 }
 
 
-void B18TrafficSP::convertVector(std::vector<abm::graph::vertex_t> paths_SP, std::vector<uint>& indexPathVec, std::map<std::shared_ptr<abm::Graph::Edge>, uint> &edgeDescToLaneMapNumSP, const std::shared_ptr<abm::Graph>& graph_) {
-    for (auto& x: paths_SP) {
-        if (x != -1) {
-            indexPathVec.emplace_back(edgeDescToLaneMapNumSP[graph_->edges_[graph_->edge_ids_to_vertices[x]]]);
+void B18TrafficSP::convertVector(std::vector<abm::graph::edge_id_t> paths_SP, std::vector<uint>& indexPathVec,  std::vector<uint> &edgeIdToLaneMapNum, const std::shared_ptr<abm::Graph>& graph_) {
+    for (abm::graph::edge_id_t& edge_in_path: paths_SP) {
+        if (edge_in_path != -1) {
+            indexPathVec.emplace_back(edgeIdToLaneMapNum[edge_in_path]);
         } else {
             indexPathVec.emplace_back(-1);
         }

--- a/LivingCity/traffic/b18TrafficSP.h
+++ b/LivingCity/traffic/b18TrafficSP.h
@@ -46,7 +46,7 @@ class B18TrafficSP {
   
   static std::vector<float> read_dep_times(const std::string& filename);
 
-  static void convertVector(std::vector<abm::graph::vertex_t> paths_SP, std::vector<uint>& indexPathVec, std::map<std::shared_ptr<abm::Graph::Edge>, uint> &edgeDescToLaneMapNumSP, const std::shared_ptr<abm::Graph>& graph_);
+  static void convertVector(std::vector<abm::graph::edge_id_t> paths_SP, std::vector<uint>& indexPathVec, std::vector<uint> &edgeIdToLaneMapNum, const std::shared_ptr<abm::Graph>& graph_);
 
   explicit B18TrafficSP(const std::shared_ptr<abm::Graph>& graph) : graph_{graph} {};
  private:

--- a/LivingCity/traffic/b18TrafficSimulator.h
+++ b/LivingCity/traffic/b18TrafficSimulator.h
@@ -71,9 +71,10 @@ class B18TrafficSimulator {
   //                   bool useJohnsonRouting, bool useSP);
   
   void simulateInGPU(int numOfPasses, float startTimeH, float endTimeH,
-    bool useJohnsonRouting, bool useSP, const std::shared_ptr<abm::Graph>& graph_, std::vector<abm::graph::vertex_t> paths_SP);
+    bool useJohnsonRouting, bool useSP, const std::shared_ptr<abm::Graph>& graph_, std::vector<abm::graph::edge_id_t> paths_SP);
 
   // Lanes
+  std::vector<uint> edgeIdToLaneMapNum;
   std::vector<uchar> laneMap;
   std::vector<B18EdgeData> edgesData;
   std::map<RoadGraph::roadGraphEdgeDesc_BI, uint> edgeDescToLaneMapNum;

--- a/LivingCity/traffic/sp/config.h
+++ b/LivingCity/traffic/sp/config.h
@@ -5,6 +5,7 @@ namespace abm {
 namespace graph {
 //! Vertex id type
 using vertex_t = long long;
+using edge_id_t = long long;
 //! Weight type, that can be added with +
 using weight_t = double;
 }  // namespace graph

--- a/LivingCity/traffic/sp/graph.h
+++ b/LivingCity/traffic/sp/graph.h
@@ -148,7 +148,7 @@ class Graph {
   std::map<std::shared_ptr<Edge>, std::tuple<graph::vertex_t, graph::vertex_t>>
       edge_pointer_to_vertices_;
   //Edges to an index
-  std::map <graph::vertex_t, graph::vertex_t> edge_vertex_map_;
+  std::map <graph::edge_id_t, graph::vertex_t> edge_vertex_map_;
   // adjacency list with iteration over each edge
   tsl::robin_map<graph::vertex_t, std::vector<std::shared_ptr<Edge>>>
       vertex_edges_;
@@ -161,16 +161,16 @@ class Graph {
   // Vertices and counts
   tsl::robin_map<graph::vertex_t, graph::vertex_t> vertices_;
   // Global edges
-  std::map<std::tuple<graph::vertex_t, graph::vertex_t>, graph::vertex_t>
+  std::map<std::tuple<graph::vertex_t, graph::vertex_t>, graph::edge_id_t>
       edge_ids_;
 
   //person to their initial edge
-  std::map<graph::vertex_t, graph::vertex_t> person_to_init_edge_;
+  std::map<graph::vertex_t, graph::edge_id_t> person_to_init_edge_;
 
-  std::map<graph::vertex_t, std::tuple<graph::vertex_t, graph::vertex_t>>
+  std::map<graph::edge_id_t, std::tuple<graph::vertex_t, graph::vertex_t>>
       edge_ids_to_vertices;
   // Vertices and counts
-  tsl::robin_map<graph::vertex_t, graph::weight_t> edge_costs_;
+  tsl::robin_map<graph::edge_id_t, graph::weight_t> edge_costs_;
 };
 
 }  // namespace abm


### PR DESCRIPTION
Issue: #3 
- Adds _edge_id_t_ type (equivalent to _long long_).
- Adds extra structure to support _edge_id_t_ to _LaneMapNum_ mapping.
- Reduces _convertVector_ duration from ~6.5mins to ~6 segs.
- Also outputs _indexPathVec_ to a file in the same way the _people_ and _route_ files are outputted.