### PR TITLE
System tests

### DIFF
--- a/LivingCity/tests/systemTestSuite.py
+++ b/LivingCity/tests/systemTestSuite.py
@@ -1,0 +1,98 @@
+""" System tests that consider LivingCity as a black box,
+    where inputs are given and outputs are validated to be correct
+
+    REQUIREMENTS: pytest (Install with pip3 install pytest)
+"""
+
+import subprocess
+import filecmp
+import re
+import pytest
+import pandas as pd
+from pdb import set_trace as st  # used for debugging
+
+
+def write_options_file(params):
+    filedata = """[General]
+                GUI=false
+                USE_CPU=false
+                NETWORK_PATH=berkeley_2018/new_full_network/
+                USE_JOHNSON_ROUTING=false
+                USE_SP_ROUTING=true
+                USE_PREV_PATHS=false
+                LIMIT_NUM_PEOPLE=256000
+                ADD_RANDOM_PEOPLE=false
+                NUM_PASSES=1
+                TIME_STEP=0.5
+                START_HR=5
+                END_HR=12
+                """
+
+    for (parameter_name, parameter_value) in params.items():
+        filedata = re.sub('{}=(-|(0-9)|.)*\n'.format(parameter_name),
+                          "{}={}\n".format(parameter_name, parameter_value),
+                          filedata)
+
+    with open('command_line_options.ini', 'w') as file:
+        file.write(filedata)
+
+
+""" 
+    * Runs LivingCity with prev_paths = false and then with prev_paths = true
+    * Produces 0_people5to12_first_run.csv, 0_indexPathVec5to12_first_run.csv, 0_route5to12_first_run.csv on the first run
+    * Produces 0_people5to12_second_run.csv, 0_indexPathVec5to12_second_run.csv, 0_route5to12_second_run.csv on the second run
+    * Should be no difference between route and indexPathVec files
+    * Should be no difference in certain columns of the people files:
+        p,init_intersection,end_intersection,time_departure,distance,a,b,T
+"""
+# ========================== Aux ==========================
+def aux_prev_paths_preserve_output_files_in_given_network(network_path):
+    output_files = ["route", "people", "indexPathVec"]
+
+    # Previous files are deleted
+    for f in output_files:
+        subprocess.call(
+            "rm ./0_{0}5to12.csv ./0_people5to12_first_run.csv ./0_{0}5to12_{0}_run.csv".format(f), shell=True)
+
+    # First run
+    write_options_file({"NETWORK_PATH":"{}".format(network_path), "USE_PREV_PATHS":"false"})
+    subprocess.run(["./LivingCity", "&"])
+    for f in output_files:
+        subprocess.call(
+            "mv ./0_{0}5to12.csv ./0_{0}5to12_first_run.csv".format(f), shell=True)
+
+    # Second run
+    write_options_file({"NETWORK_PATH":"{}".format(network_path), "USE_PREV_PATHS":"true"})
+    subprocess.run(["./LivingCity", "&"])
+    for f in output_files:
+        subprocess.call(
+            "mv ./0_{0}5to12.csv ./0_{0}5to12_second_run.csv".format(f), shell=True)
+
+    # Compare both runs, routes and indexPathVec should be equal
+    for f in ["route", "indexPathVec"]:
+        assert filecmp.cmp("0_{0}5to12_first_run.csv".format(f), "0_{0}5to12_second_run.csv".format(
+            f), shallow=False), "{} file are not equal between runs".format(f)
+
+    # Compare both people files, they should be equal in certain columns:
+    for (row_first_run, row_second_run) in pd.read_csv("0_people5to12_first_run.csv", "0_people5to12_second_run.csv"):
+        parameters_that_should_be_equal = [
+            "p", "init_intersection", "end_intersection", "time_departure", "distance", "a", "b", "T"]
+        for param in parameters_that_should_be_equal:
+            assert row_first_run[param] == row_second_run, "{} parameter is not equal in the people file between runs".format(
+                param)
+
+
+# ========================== Tests ==========================
+
+@pytest.mark.skip()
+def test01_prev_paths_preserve_output_files_in_small_network_1():
+    aux_prev_paths_preserve_output_files_in_given_network("test/small_network_1")
+
+@pytest.mark.skip()
+def test02_prev_paths_preserve_output_files_in_small_network_2():
+    aux_prev_paths_preserve_output_files_in_given_network("test/small_network_2")
+
+def test03_prev_paths_preserve_output_files_in_new_full_network():
+    aux_prev_paths_preserve_output_files_in_given_network("berkeley_2018/new_full_network/")
+
+test03_prev_paths_preserve_output_files_in_new_full_network()

--- a/LivingCity/tests/systemTestSuite.py
+++ b/LivingCity/tests/systemTestSuite.py
@@ -150,7 +150,7 @@ def test03_prev_paths_should_have_consistent_people_files(network_setup):
 def test_04_distance_in_people_file_should_match_the_sum_of_the_edges_in_the_route_file(network_setup):
     log("Comparing that the distance in the people file matches the sum of the edges in the route file with a margin of {}...".format(
         pytest.distance_margin_between_route_and_people_file))
-    log("(Since testing for > 2 million people takes several hours, it is tested on 1.000 random people).")
+    log("(Since testing for > 2 million people takes several hours, it is tested on 10.000 random people).")
     pd_people = pd.read_csv("0_people5to12_first_run.csv")
     pd_edges = pd.read_csv(pytest.edges_path)
 

--- a/LivingCity/tests/systemTestSuite.py
+++ b/LivingCity/tests/systemTestSuite.py
@@ -1,14 +1,22 @@
-""" System tests that consider LivingCity as a black box,
-    where inputs are given and outputs are validated to be correct
+""" This file contains system tests that consider LivingCity as a black box,
+    where inputs are given and outputs are validated.
 
-    REQUIREMENTS: pytest (Install with pip3 install pytest)
+    Requirements under linux:
+    - Python 3.6.5
+    - pytest 6.1.1
+    - pytest-cov 2.10.1
+    - pytest-remotedata 0.3.2
 """
 
 import subprocess
+import random
 import filecmp
 import re
 import pytest
 import pandas as pd
+from termcolor import colored
+import csv
+from tqdm import tqdm
 from pdb import set_trace as st  # used for debugging
 
 
@@ -37,62 +45,143 @@ def write_options_file(params):
         file.write(filedata)
 
 
-""" 
+# ========================== Aux ==========================
+def log(text):
+    print(colored(text, 'cyan'))
+
+
+def length_of_csv(csv_file, delimiter):
+    with open(csv_file) as file_object:
+        return sum(1 for row in file_object)
+
+
+# ========================== Tests ==========================
+# Global variables across tests
+pytest.network_setup_has_run = False
+pytest.network_path = "berkeley_2018/new_full_network/"
+pytest.number_of_people = 3441952
+pytest.distance_margin_between_route_and_people_file = 100
+pytest.edges_path = "berkeley_2018/new_full_network/edges.csv"
+
+"""
+network_setup runs automatically before the tests that take network_setup as a parameter
+For each network specified it does the following:
     * Runs LivingCity with prev_paths = false and then with prev_paths = true
     * Produces 0_people5to12_first_run.csv, 0_indexPathVec5to12_first_run.csv, 0_route5to12_first_run.csv on the first run
     * Produces 0_people5to12_second_run.csv, 0_indexPathVec5to12_second_run.csv, 0_route5to12_second_run.csv on the second run
-    * Should be no difference between route and indexPathVec files
-    * Should be no difference in certain columns of the people files:
-        p,init_intersection,end_intersection,time_departure,distance,a,b,T
 """
-# ========================== Aux ==========================
-def aux_prev_paths_preserve_output_files_in_given_network(network_path):
+
+
+@pytest.fixture(params=["berkeley_2018/new_full_network/"], ids=["new_full_network"])
+def network_setup(request):
+    network_path = pytest.network_path
+
+    if pytest.network_setup_has_run or "--skip-setup" in pytest.options:
+        return network_path
+    pytest.network_setup_has_run = True
+
+    log("\nRunning setup")
+    log("Running system test on output files for network {}".format(network_path))
     output_files = ["route", "people", "indexPathVec"]
 
-    # Previous files are deleted
+    log("Removing previous run files...")
     for f in output_files:
         subprocess.call(
             "rm ./0_{0}5to12.csv ./0_people5to12_first_run.csv ./0_{0}5to12_{0}_run.csv".format(f), shell=True)
 
-    # First run
-    write_options_file({"NETWORK_PATH":"{}".format(network_path), "USE_PREV_PATHS":"false"})
+    log("Running first simulation with use_prev_paths=false...")
+    write_options_file({"NETWORK_PATH": "{}".format(
+        network_path), "USE_PREV_PATHS": "false"})
     subprocess.run(["./LivingCity", "&"])
     for f in output_files:
         subprocess.call(
             "mv ./0_{0}5to12.csv ./0_{0}5to12_first_run.csv".format(f), shell=True)
 
-    # Second run
-    write_options_file({"NETWORK_PATH":"{}".format(network_path), "USE_PREV_PATHS":"true"})
+    log("Running second simulation with use_prev_paths=true...")
+    write_options_file({"NETWORK_PATH": "{}".format(
+        network_path), "USE_PREV_PATHS": "true"})
     subprocess.run(["./LivingCity", "&"])
     for f in output_files:
         subprocess.call(
             "mv ./0_{0}5to12.csv ./0_{0}5to12_second_run.csv".format(f), shell=True)
 
-    # Compare both runs, routes and indexPathVec should be equal
-    for f in ["route", "indexPathVec"]:
-        assert filecmp.cmp("0_{0}5to12_first_run.csv".format(f), "0_{0}5to12_second_run.csv".format(
-            f), shallow=False), "{} file are not equal between runs".format(f)
+    log("Finished setup.")
 
-    # Compare both people files, they should be equal in certain columns:
-    for (row_first_run, row_second_run) in pd.read_csv("0_people5to12_first_run.csv", "0_people5to12_second_run.csv"):
+    return network_path
+
+
+def test01_all_output_files_should_have_the_same_length(network_setup):
+    lengths = []
+    log("Checking that the length of people and route files are the same...")
+    for output_file in ["route", "people"]:
+        delimiter = ":" if output_file == "route" else ","
+        lengths.append(length_of_csv(
+            '0_{}5to12_first_run.csv'.format(output_file), delimiter))
+    assert all([lengths[0] == elem for elem in lengths])
+    pytest.number_of_people = lengths[0]
+    log("Passed")
+
+
+@pytest.mark.parametrize("file_to_preserve", ["route", "indexPathVec"])
+def test02_prev_paths_should_preserve_route_and_indexPathVec_files(network_setup, file_to_preserve):
+    log("Comparing {} files between the two runs...".format(file_to_preserve))
+    assert filecmp.cmp("0_{0}5to12_first_run.csv".format(file_to_preserve), "0_{0}5to12_second_run.csv".format(
+        file_to_preserve), shallow=False), "{} file are not equal between runs".format(file_to_preserve)
+    log("Passed")
+
+
+def test03_prev_paths_should_have_consistent_people_files(network_setup):
+    log("Comparing people files between the two runs...")
+
+    df_first_run = pd.read_csv("0_people5to12_first_run.csv")
+    df_second_run = pd.read_csv("0_people5to12_second_run.csv")
+    for (id_row, row_first_run), (_, row_second_run) in tqdm(zip(df_first_run.iterrows(), df_second_run.iterrows()),
+                                                             total=pytest.number_of_people):
         parameters_that_should_be_equal = [
-            "p", "init_intersection", "end_intersection", "time_departure", "distance", "a", "b", "T"]
+            "p", "init_intersection", "end_intersection", "time_departure", "a", "b", "T"]
         for param in parameters_that_should_be_equal:
-            assert row_first_run[param] == row_second_run, "{} parameter is not equal in the people file between runs".format(
-                param)
+            assert row_first_run[param] == row_second_run[param], \
+                "{} parameter is not equal in the people file between runs for row {}.".format(param, id_row) +\
+                "First column has {} while second column has {}.".format(
+                row_first_run[param], row_second_run[param])
+    log("Passed")
 
 
-# ========================== Tests ==========================
+def test_04_distance_in_people_file_should_match_the_sum_of_the_edges_in_the_route_file(network_setup):
+    log("Comparing that the distance in the people file matches the sum of the edges in the route file with a margin of {}...".format(
+        pytest.distance_margin_between_route_and_people_file))
+    log("(Since testing for > 2 million people takes several hours, it is tested on 1.000 random people).")
+    pd_people = pd.read_csv("0_people5to12_first_run.csv")
+    pd_edges = pd.read_csv(pytest.edges_path)
 
-@pytest.mark.skip()
-def test01_prev_paths_preserve_output_files_in_small_network_1():
-    aux_prev_paths_preserve_output_files_in_given_network("test/small_network_1")
+    people_to_test = [random.randint(
+        0, pytest.number_of_people) for i in range(10000)]
 
-@pytest.mark.skip()
-def test02_prev_paths_preserve_output_files_in_small_network_2():
-    aux_prev_paths_preserve_output_files_in_given_network("test/small_network_2")
+    for chunk_route in tqdm(pd.read_csv("0_route5to12_first_run.csv", sep=":", chunksize=1000),
+                            total=pytest.number_of_people/1000):
+        for _, row in chunk_route.iterrows():
+            person_id = str(row["p"])
 
-def test03_prev_paths_preserve_output_files_in_new_full_network():
-    aux_prev_paths_preserve_output_files_in_given_network("berkeley_2018/new_full_network/")
+            if (not person_id in people_to_test):
+                continue
 
-test03_prev_paths_preserve_output_files_in_new_full_network()
+            route = str(row["route"])
+            route = route.replace("[", "").replace("]", "")
+            route = route.split(",")
+            route = route[:-1]  # delete last extra comma
+
+            distance_sum_of_edges = 0
+            for edge_id in route:
+                distance_sum_of_edges += pd_edges.loc[int(edge_id)]["length"]
+
+            distance_people_info = pd_people.loc[int(person_id)]['distance']
+
+            error_message = "Discrepancy has been found for person {}. \
+                            Distance according to people info: {}. \
+                            Distance according to sum of edges: {}.\n Stopping.". \
+                            format(person_id, distance_people_info,
+                                   distance_sum_of_edges)
+            assert abs(distance_people_info -
+                       distance_sum_of_edges) < pytest.distance_margin_between_route_and_people_file, error_message
+
+    log("Passed")

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Microsimulation Analysis for Network Traffic Assignment. MANTA employs a highly 
  - g++ (used versions: 6.4.0 in Ubuntu)
  - Qt5 (used versions: 5.9.5 in Ubuntu)
  - qmake (used versions: 3.1 in Ubuntu)
- - pytest (used versions: 6.1.1 in Ubuntu)
+ - Python (used versions: 3.6.5 in Ubuntu)
+ - pytest (used versions: 6.1.1 in Ubuntu) 
+ - pytest-cov (used versions: 2.10.1 in Ubuntu) 
+ - pytest-remotedata (used versions: 0.3.2 in Ubuntu) 
+
 
 ## Installation & Compilation
 
@@ -174,12 +178,10 @@ cd LivingCity
 ```
 and then run 
 ```bash
-pytest tests/systemTestSuite.py
+pytest -s -x tests/systemTestSuite.py
 ```
-If you wish to see the output of each simulation add the `-s` flag in the following way
-```bash
-pytest -s tests/systemTestSuite.py
-```
+Because of the tests' long duration, we recommend using the flag `-s` to show the whole output of the simulation and `-x` to stop at the first failure.
+
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Microsimulation Analysis for Network Traffic Assignment. MANTA employs a highly 
  - g++ (used versions: 6.4.0 in Ubuntu)
  - Qt5 (used versions: 5.9.5 in Ubuntu)
  - qmake (used versions: 3.1 in Ubuntu)
+ - pytest (used versions: 6.1.1 in Ubuntu)
 
 ## Installation & Compilation
 
@@ -165,6 +166,20 @@ ${OBJECTS_DIR}b18CUDA_trafficSimulator_cuda.o
 After this modification, `sudo make clean` and `sudo make -j` must be run.
 
 Please keep in mind that this alteration slows the program down. For more information about `cuda-gdb`, please refer to the official [Website](https://docs.nvidia.com/cuda/cuda-gdb/index.html) and [Documentation](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwiBgbqg9fzrAhUMIrkGHby9Db8QFjADegQIAxAB&url=https%3A%2F%2Fdeveloper.download.nvidia.com%2Fcompute%2FDevZone%2Fdocs%2Fhtml%2FC%2Fdoc%2Fcuda-gdb.pdf&usg=AOvVaw3J9Il2vHkkxtcX83EHC3-z).
+
+### Testing
+In order to run the system tests you should first move to `manta/LivingCity`
+```bash
+cd LivingCity
+```
+and then run 
+```bash
+pytest tests/systemTestSuite.py
+```
+If you wish to see the output of each simulation add the `-s` flag in the following way
+```bash
+pytest -s tests/systemTestSuite.py
+```
 
 ## Acknowledgments
 


### PR DESCRIPTION
Issue #7.
In order to facilitate the debugging of the branch `fast_micro_with_edges_speeds`, which should fix #7, some system tests of increasing complexity were developed. All of them consider `LivingCity` as a black box, and test its output based on specific configurations.

The tests added are:
- Test 01, which checks that people and route files should have the same number of people.
- Test 02, which checks that running the network using _prev_paths_ should have the same route and indexPathVec files as the previous run. Currently `fast_micro_with_edges_speeds` cannot pass it.
- Test 03, which checks that running the network using `prev_paths` should have consistent people files with the previous run. Currently `fast_micro_with_edges_speeds` cannot pass it.
- Test 04, which checks that the distance in the people file should match the sum of the edges in the route file. This one is related to the index mismatch of issue #1 and currently `fast_micro_with_edges_speeds` can pass it.