### PR TITLE
File output multithreading

### DIFF
--- a/LivingCity/benchmarking/runBenchmarks.py
+++ b/LivingCity/benchmarking/runBenchmarks.py
@@ -39,7 +39,7 @@ def write_options_file(params = None):
                             "START_HR=5",\
                             "END_HR=12",\
                             "SHOW_BENCHMARKS=true",\
-                            "OD_DEMAND_FILENAME=od_demand_5to12_different_one.csv", \
+                            "OD_DEMAND_FILENAME=od_demand_5to12.csv", \
                             " "])
 
     if params is not None:

--- a/LivingCity/benchmarking/runBenchmarks.py
+++ b/LivingCity/benchmarking/runBenchmarks.py
@@ -39,7 +39,7 @@ def write_options_file(params = None):
                             "START_HR=5",\
                             "END_HR=12",\
                             "SHOW_BENCHMARKS=true",\
-                            "OD_DEMAND_FILENAME=od_demand_5to12.csv", \
+                            "OD_DEMAND_FILENAME=od_demand_5to12_different_one.csv", \
                             " "])
 
     if params is not None:

--- a/LivingCity/roadGraphB2018Loader.cpp
+++ b/LivingCity/roadGraphB2018Loader.cpp
@@ -378,7 +378,7 @@ std::string RoadGraphB2018::loadABMGraph(
   const std::string& nodeFileName = networkPath + "nodes.csv";
   std::cout << nodeFileName << " as nodes file\n";
 
-  const std::string& odFileName = networkPath + "/" + odDemandPath;
+  const std::string& odFileName = networkPath + odDemandPath;
   std::cout << odFileName << " as OD file\n";
 
   auto start = high_resolution_clock::now();

--- a/LivingCity/traffic/b18TrafficSimulator.h
+++ b/LivingCity/traffic/b18TrafficSimulator.h
@@ -115,7 +115,11 @@ class B18TrafficSimulator {
 
   void calculateAndDisplayTrafficDensity(int numOfPass);
   void savePeopleAndRoutes(int numOfPass);
-  void savePeopleAndRoutesSP(int numOfPass, const std::shared_ptr<abm::Graph>& graph_, std::vector<abm::graph::edge_id_t> paths_SP, int start_time, int end_time);
+  void savePeopleAndRoutesSP(int numOfPass,
+    const std::shared_ptr<abm::Graph>& graph_,
+    const std::vector<abm::graph::edge_id_t>& paths_SP,
+    int start_time, int end_time);
+    
 #ifdef B18_RUN_WITH_GUI
   void render(VBORenderManager &rendManager);
 #endif


### PR DESCRIPTION
Issue: #17 
- Enables the possibility of writing each output file in a different thread, thus reducing the total writing time in half.
- Fixes a small bug in the `od_demand` parametrization.
![image](https://user-images.githubusercontent.com/8797947/101822979-e7394780-3b08-11eb-85db-87f749663396.png)
